### PR TITLE
write tag permission

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   package-and-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
write tag permission should allow for creating xrnx packages with github actions without erroring out